### PR TITLE
Add else condition if API call returns none

### DIFF
--- a/custom_components/vesync/pyvesync/vesyncfan.py
+++ b/custom_components/vesync/pyvesync/vesyncfan.py
@@ -877,8 +877,11 @@ class VeSyncHumid200300S(VeSyncBaseDevice):
         )
         if r is None or not isinstance(r, dict):
             logger.debug("Error getting status of %s ", self.device_name)
-        outer_result = r.get("result", {})
-        inner_result = None
+            outer_result = None
+            inner_result = None
+        else:
+            outer_result = r.get("result", {})
+            inner_result = None
 
         if outer_result is not None:
             inner_result = r.get("result", {}).get("result")


### PR DESCRIPTION
I was getting exceptions when the API call returned none.

It has been suggested to the Library owner as well.