### PR TITLE
Add Warm Mist attributes

### DIFF
--- a/custom_components/vesync/humidifier.py
+++ b/custom_components/vesync/humidifier.py
@@ -136,6 +136,12 @@ class VeSyncHumidifierHA(VeSyncDevice, HumidifierEntity):
         if "mist_level" in self.smarthumidifier.details:
             attr["mist_level"] = self.smarthumidifier.details["mist_level"]
 
+        if "warm_mist_level" in self.smarthumidifier.details:
+            attr["warm_mist_level"] = self.smarthumidifier.details["warm_mist_level"]
+
+        if "warm_mist_enabled" in self.smarthumidifier.details:
+            attr["warm_mist_enabled"] = self.smarthumidifier.details["warm_mist_enabled"]
+
         return attr
 
     def set_humidity(self, humidity):

--- a/custom_components/vesync/humidifier.py
+++ b/custom_components/vesync/humidifier.py
@@ -140,7 +140,9 @@ class VeSyncHumidifierHA(VeSyncDevice, HumidifierEntity):
             attr["warm_mist_level"] = self.smarthumidifier.details["warm_mist_level"]
 
         if "warm_mist_enabled" in self.smarthumidifier.details:
-            attr["warm_mist_enabled"] = self.smarthumidifier.details["warm_mist_enabled"]
+            attr["warm_mist_enabled"] = self.smarthumidifier.details[
+                "warm_mist_enabled"
+            ]
 
         return attr
 


### PR DESCRIPTION
These could possibly be added as sensor entities in their own right.

I cannot test them but there was a comment by someone on the original PR about this.

Ideally, I suggest, these should be number and binary entities as well but I was going to check the attributes appeared first.