### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -9,5 +9,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3.2.0
       - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -7,6 +7,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-python@v4.3.0
+      - uses: actions/checkout@v3.2.0
+      - uses: actions/setup-python@v4.3.1
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3.1.0"
+      - uses: "actions/checkout@v3.2.0"
       - name: HACS validation
         uses: "hacs/action@22.5.0"
         with:

--- a/.github/workflows/workflow_updater.yaml
+++ b/.github/workflows/workflow_updater.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3.2.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.2.0](https://github.com/actions/checkout/releases/tag/v3.2.0)** on 2022-12-12T19:14:01Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.3.1](https://github.com/actions/setup-python/releases/tag/v4.3.1)** on 2022-12-08T12:23:19Z
