### PR TITLE
Setting device class and unit of measurement for target humidity entities

### DIFF
--- a/custom_components/vesync/number.py
+++ b/custom_components/vesync/number.py
@@ -1,7 +1,9 @@
 """Support for number settings on VeSync devices."""
 
 from homeassistant.components.number import NumberEntity
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
@@ -194,6 +196,23 @@ class VeSyncHumidifierTargetLevelHA(VeSyncNumberEntity):
     def native_value(self):
         """Return the current target humidity level."""
         return self.device.config["auto_target_humidity"]
+
+    @property
+    def native_unit_of_measurement(self):
+        """Return the native unit of measurement for the target humidity level."""
+        return PERCENTAGE
+
+    @property
+    def device_class(self):
+        """
+        Return the device class of the target humidity level.
+
+        Eventually this should become NumberDeviceClass but that was introduced in 2022.12.
+        For maximum compatibility, using SensorDeviceClass as recommended by deprecation notice.
+        Or hard code this to "humidity"
+        """
+
+        return SensorDeviceClass.HUMIDITY
 
     def set_native_value(self, value):
         """Set the target humidity level."""


### PR DESCRIPTION
Currently the target humidity number entities do not publish their device class and unit of measurements. This PR adds those pieces of metadata to the component allowing things like graphing to be easier.

History graph before this change: 
![image](https://user-images.githubusercontent.com/109995/207417215-6ca70570-259b-4359-9981-96a843c6da23.png)

History graph after this change:
![image](https://user-images.githubusercontent.com/109995/207417286-405cfacc-3cfb-4da7-b1f6-af85859e5556.png)

As mentioned in a code comment, eventually `SensorDeviceClass` should probably become `NumberDeviceClass` but that seems incredibly limiting as `NumberDeviceClass` was just introduced.