### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -9,5 +9,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.4.0
       - uses: home-assistant/actions/hassfest@1.0.0

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -7,6 +7,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.4.0
       - uses: actions/setup-python@v4.5.0
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
-        uses: release-drafter/release-drafter@v5.22.0
+        uses: release-drafter/release-drafter@v5.23.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3.3.0"
+      - uses: "actions/checkout@v3.4.0"
       - name: HACS validation
         uses: "hacs/action@22.5.0"
         with:

--- a/.github/workflows/workflow_updater.yaml
+++ b/.github/workflows/workflow_updater.yaml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.4.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.3
+        uses: saadmk11/github-actions-version-updater@v0.7.4
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.7.4](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.4)** on 2023-03-15T16:41:04Z
* **[release-drafter/release-drafter](https://github.com/release-drafter/release-drafter)** published a new release **[v5.23.0](https://github.com/release-drafter/release-drafter/releases/tag/v5.23.0)** on 2023-02-21T09:25:20Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.4.0](https://github.com/actions/checkout/releases/tag/v3.4.0)** on 2023-03-15T19:47:24Z
