### PR TITLE
LV131 air_quality is an Enum, not AQI

### DIFF
--- a/custom_components/vesync/sensor.py
+++ b/custom_components/vesync/sensor.py
@@ -211,8 +211,8 @@ class VeSyncAirQualitySensor(VeSyncHumidifierSensorEntity):
 
     @property
     def state_class(self):
-        """Return the measurement state class."""
-        return SensorStateClass.MEASUREMENT
+        """Return the none state class."""
+        return None
 
     @property
     def native_value(self):

--- a/custom_components/vesync/sensor.py
+++ b/custom_components/vesync/sensor.py
@@ -206,6 +206,7 @@ class VeSyncAirQualitySensor(VeSyncHumidifierSensorEntity):
     @property
     def options(self):
         """Return the air quality options."""
+        # Note that while the manual (https://cdn.accentuate.io/4847302017112/1617079386388/02.00_M1_LV-H131-RWH-Grayscale_2021-03-02_US_en-revised.pdf?v=0) specifies the top air quality as "very good" the API actually reports "Excellent".
         return ["Excellent", "Good", "Moderate", "Bad"]
 
     @property

--- a/custom_components/vesync/sensor.py
+++ b/custom_components/vesync/sensor.py
@@ -184,9 +184,6 @@ class VeSyncHumidifierSensorEntity(VeSyncBaseEntity, SensorEntity):
 class VeSyncAirQualitySensor(VeSyncHumidifierSensorEntity):
     """Representation of an air quality sensor."""
 
-    _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_device_class = SensorDeviceClass.AQI
-
     def __init__(self, plug, coordinator):
         """Initialize the VeSync outlet device."""
         super().__init__(plug, coordinator)
@@ -200,6 +197,21 @@ class VeSyncAirQualitySensor(VeSyncHumidifierSensorEntity):
     def name(self):
         """Return sensor name."""
         return f"{super().name} air quality"
+
+    @property
+    def device_class(self):
+        """Return the air quality device class."""
+        return SensorDeviceClass.ENUM
+    
+    @property
+    def options(self):
+        """Return the air quality options."""
+        return ["Excellent", "Good", "Moderate", "Bad"]
+
+    @property
+    def state_class(self):
+        """Return the measurement state class."""
+        return SensorStateClass.MEASUREMENT
 
     @property
     def native_value(self):


### PR DESCRIPTION
I'm not sure this change works across all devices, but it definitely works for the LV131.  I've made the change in my fork, and I'd be HAPPY to learn how to limit this to the specific devices it applies to, but I figured I'd open the PR and see if I could get a little help with that.

The problem is that this integration has been using `SensorDeviceClass.AQI` to report the air quality from the LV131.  However, AIR must now be numerical, whereas the LV131 returns a string, rather than an actual AQI number.  I think it's only recently that HA has started enforcing numerical values (not string) in https://github.com/home-assistant/core/blob/dev/homeassistant/components/sensor/__init__.py#L465, because there used to be a warning and now it's just broken.   Without the change in my PR, the LV131 air quality sensor is disabled, and the HA logs include `ValueError` with a message that it can't accept a string as a numerical value.