### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -10,5 +10,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
-      - uses: home-assistant/actions/hassfest@master
+      - uses: "actions/checkout@v3.5.2"
+      - uses: home-assistant/actions/hassfest@1.0.0

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -8,5 +8,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
-      - uses: actions/setup-python@v4.5.0
+      - uses: actions/setup-python@v4.6.1
       - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.6.1](https://github.com/actions/setup-python/releases/tag/v4.6.1)** on 2023-05-24T14:12:35Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.2](https://github.com/actions/checkout/releases/tag/v3.5.2)** on 2023-04-13T12:49:40Z
* **[home-assistant/actions](https://github.com/home-assistant/actions)** published a new release **[1.0.0](https://github.com/home-assistant/actions/releases/tag/1.0.0)** on 2020-04-16T23:08:38Z
