### PR TITLE
Change device info "default_manufacturer" to "manufacturer" - Fix for HA 2023.8

### DIFF
--- a/custom_components/vesync/common.py
+++ b/custom_components/vesync/common.py
@@ -149,7 +149,7 @@ class VeSyncBaseEntity(CoordinatorEntity, Entity):
             "identifiers": {(DOMAIN, self.base_unique_id)},
             "name": self.base_name,
             "model": self.device.device_type,
-            "default_manufacturer": "VeSync",
+            "manufacturer": "VeSync",
             "sw_version": self.device.current_firm_version,
         }
 


### PR DESCRIPTION
Currently running the beta for Home Assistant 2023.8. It looks like they have introduced a validator in the device registry that now checks the validity of an entity's device info.

Starting with 2023.8, the following error is logged for all entities:

```
Logger: homeassistant.components.number
Source: helpers/entity_platform.py:624
Integration: Number (documentation, issues)
First occurred: 7:06:46 PM (2 occurrences)
Last logged: 7:06:46 PM

Ignoring invalid device info: Invalid device info {'default_manufacturer': 'VeSync', 'identifiers': {('vesync', 'vsaqf650392470db518f6893d5e0f296')}, 'model': 'Classic300S', 'name': 'Bedroom Humidifier', 'sw_version': None} for 'vesync' config entry: device info needs to either describe a device, link to existing device or provide extra information.
```

The `default_manufacturer` key is part of [secondary device info](https://github.com/home-assistant/core/blob/81c0dcff63e805cec11a5e05c35da8cfb55472d2/homeassistant/helpers/device_registry.py#L68-L97) while the rest of the device info that you have is primary. This mix between primary and secondary info causes a [DeviceInfoError exception to be raised](https://github.com/home-assistant/core/blob/81c0dcff63e805cec11a5e05c35da8cfb55472d2/homeassistant/helpers/device_registry.py#L141-L174).

Changing the key to `manufacturer` instead makes Home Assistant happy as now all parts of the device info provided are primary.  