### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -7,6 +7,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.1.0
       - uses: actions/setup-python@v4.7.0
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"
-      - uses: home-assistant/actions/hassfest@1.0.0
+      - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"
-      - uses: home-assistant/actions/hassfest@master
+      - uses: home-assistant/actions/hassfest@1.0.0

--- a/.github/workflows/workflow_updater.yaml
+++ b/.github/workflows/workflow_updater.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.1.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.0](https://github.com/actions/checkout/releases/tag/v4.1.0)** on 2023-09-22T17:42:49Z
* **[home-assistant/actions](https://github.com/home-assistant/actions)** published a new release **[1.0.0](https://github.com/home-assistant/actions/releases/tag/1.0.0)** on 2020-04-16T23:08:38Z
