### PR TITLE
Add Vital100S and Vital200S support

### DIFF
--- a/custom_components/vesync/const.py
+++ b/custom_components/vesync/const.py
@@ -24,7 +24,7 @@ VS_MODE_SLEEP = "sleep"
 
 VS_TO_HA_ATTRIBUTES = {"humidity": "current_humidity"}
 
-VS_FAN_TYPES = ["VeSyncAirBypass", "VeSyncAir131"]
+VS_FAN_TYPES = ["VeSyncAirBypass", "VeSyncAir131", "VeSyncVital"]
 VS_HUMIDIFIERS_TYPES = ["VeSyncHumid200300S", "VeSyncHumid200S", "VeSyncHumid1000S"]
 
 DEV_TYPE_TO_HA = {


### PR DESCRIPTION
These devices use a different module name from the other air purifiers and are thus currently ignored. Adding this module name as a fan type fixes it.