### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3.6.0"
-      - uses: home-assistant/actions/hassfest@master
+      - uses: home-assistant/actions/hassfest@1.0.0

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -7,6 +7,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.0
-      - uses: actions/setup-python@v4.7.0
+      - uses: actions/checkout@v4.1.1
+      - uses: actions/setup-python@v4.7.1
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update release draft
-        uses: release-drafter/release-drafter@v5.24.0
+        uses: release-drafter/release-drafter@v5.25.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow_updater.yaml
+++ b/.github/workflows/workflow_updater.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[release-drafter/release-drafter](https://github.com/release-drafter/release-drafter)** published a new release **[v5.25.0](https://github.com/release-drafter/release-drafter/releases/tag/v5.25.0)** on 2023-10-17T05:09:13Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.7.1](https://github.com/actions/setup-python/releases/tag/v4.7.1)** on 2023-10-02T10:59:39Z
* **[home-assistant/actions](https://github.com/home-assistant/actions)** published a new release **[1.0.0](https://github.com/home-assistant/actions/releases/tag/1.0.0)** on 2020-04-16T23:08:38Z
